### PR TITLE
Fix aws-sdk to version 1

### DIFF
--- a/alephant-harness.gemspec
+++ b/alephant-harness.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "aws-sdk"
+  spec.add_runtime_dependency "aws-sdk", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
When running a `bundle update` to bring the cache content type fix in, I get an infinite loop when trying to resolve the aws-sdk.

I notice that alephant-sequencer has the aws-sdk fixed at version 1.0. Should this be the same for alephant-harness? It seemed odd that bundler was trying to resolve with a version 2.x of the aws-sdk.

```
Creating possibility state for alephant-harness java (6 remaining)
                    Attempting to activate alephant-harness (0.2.1)
                    Activated alephant-harness at alephant-harness (0.2.1)
                    Requiring nested dependencies (aws-sdk java)
.                    Creating possibility state for aws-sdk java (227 remaining)
                      Attempting to activate aws-sdk (2.2.15)
                      Activated aws-sdk at aws-sdk (2.2.15)
                      Requiring nested dependencies (aws-sdk-resources (= 2.2.15) java)
                      Creating possibility state for aws-sdk-resources (= 2.2.15) java (1 remaining)
                        Attempting to activate aws-sdk-resources (2.2.15)
                        Activated aws-sdk-resources at aws-sdk-resources (2.2.15)
                        Requiring nested dependencies (aws-sdk-core (= 2.2.15) java)
                        Creating possibility state for aws-sdk-core (= 2.2.15) java (1 remaining)
                          Attempting to activate aws-sdk-core (2.2.15)
                          Activated aws-sdk-core at aws-sdk-core (2.2.15)
...
Creating possibility state for aws-sdk (~> 1.0) java (139 remaining)
                                            Attempting to activate aws-sdk (1.59.1)
                                            Found existing spec (aws-sdk (2.2.15))
                                            Unsatisfied by existing spec (aws-sdk (2.2.15))
                                            Unwinding for conflict: aws-sdk (~> 1.0) java
                                          Creating possibility state for aws-sdk (~> 1.0) java (138 remaining)
                                            Attempting to activate aws-sdk (1.59.0)
                                            Found existing spec (aws-sdk (2.2.15))
                                            Unsatisfied by existing spec (aws-sdk (2.2.15))
                                            Unwinding for conflict: aws-sdk (~> 1.0) java
                                          Creating possibility state for aws-sdk (~> 1.0) java (137 remaining)
                                            Attempting to activate aws-sdk (1.58.0)
                                            Found existing spec (aws-sdk (2.2.15))
                                            Unsatisfied by existing spec (aws-sdk (2.2.15))
                                            Unwinding for conflict: aws-sdk (~> 1.0) java
                                          Creating possibility state for aws-sdk (~> 1.0) java (136 remaining)
                                            Attempting to activate aws-sdk (1.57.0)
                                            Found existing spec (aws-sdk (2.2.15))
                                            Unsatisfied by existing spec (aws-sdk (2.2.15))
                                            Unwinding for conflict: aws-sdk (~> 1.0) java
                                          Creating possibility state for aws-sdk (~> 1.0) java (135 remaining)
                                            Attempting to activate aws-sdk (1.56.0)
                                            Found existing spec (aws-sdk (2.2.15))
                                            Unsatisfied by existing spec (aws-sdk (2.2.15))
                                            Unwinding for conflict: aws-sdk (~> 1.0) java
                                          Creating possibility state for aws-sdk (~> 1.0) java (134 remaining)
                                            Attempting to activate aws-sdk (1.55.0)
                                            Found existing spec (aws-sdk (2.2.15))
                                            Unsatisfied by existing spec (aws-sdk (2.2.15))
                                            Unwinding for conflict: aws-sdk (~> 1.0) java
                                          Creating possibility state for aws-sdk (~> 1.0) java (133 remaining)
                                            Attempting to activate aws-sdk (1.54.0)
                                            Found existing spec (aws-sdk (2.2.15))
                                            Unsatisfied by existing spec (aws-sdk (2.2.15))
                                            Unwinding for conflict: aws-sdk (~> 1.0) java
                                          Creating possibility state for aws-sdk (~> 1.0) java (132 remaining)
                                            Attempting to activate aws-sdk (1.53.0)
                                            Found existing spec (aws-sdk (2.2.15))
                                            Unsatisfied by existing spec (aws-sdk (2.2.15))
                                            Unwinding for conflict: aws-sdk (~> 1.0) java
                                          Creating possibility state for aws-sdk (~> 1.0) java (131 remaining)
                                            Attempting to activate aws-sdk (1.52.0)
                                            Found existing spec (aws-sdk (2.2.15))
                                            Unsatisfied by existing spec (aws-sdk (2.2.15))
                                            Unwinding for conflict: aws-sdk (~> 1.0) java
                                          Creating possibility state for aws-sdk (~> 1.0) java (130 remaining)
                                            Attempting to activate aws-sdk (1.51.0)
                                            Found existing spec (aws-sdk (2.2.15))
                                            Unsatisfied by existing spec (aws-sdk (2.2.15))
                                            Unwinding for conflict: aws-sdk (~> 1.0) java
                                          Creating possibility state for aws-sdk (~> 1.0) java (129 remaining)
                                            Attempting to activate aws-sdk (1.50.0)
                                            Found existing spec (aws-sdk (2.2.15))
                                            Unsatisfied by existing spec (aws-sdk (2.2.15))
                                            Unwinding for conflict: aws-sdk (~> 1.0) java
.                                          Creating possibility state for aws-sdk (~> 1.0) java (128 remaining)
...
```

![](https://media.giphy.com/media/fJdpdS5jaDje8/giphy.gif)